### PR TITLE
Debug timestamps in user's local time

### DIFF
--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -301,7 +301,7 @@ loggerFunc loc _src level msg =
              return (T.pack date <> T.pack l <> T.decodeUtf8 (fromLogStr (toLogStr msg)) <> T.pack lc)
           where getDate
                   | maxLogLevel <= LevelDebug =
-                    do now <- getCurrentTime
+                    do now <- getZonedTime
                        return (formatTime defaultTimeLocale "%Y-%m-%d %T%Q" now ++
                                ": ")
                   | otherwise = return ""


### PR DESCRIPTION
Resolves commercialhaskell/stack#1227.

I figure local times make much more sense than keeping UTC and adding on a timezone, similar to how other command line tools behave locally (I'm in AEST/GMT+11).
